### PR TITLE
fix: Rename _InjectAdditionalFiles target to avoid Uno.WinUI conflicts

### DIFF
--- a/src/Shiny.Mediator.SourceGenerators/SourceGenerators.targets
+++ b/src/Shiny.Mediator.SourceGenerators/SourceGenerators.targets
@@ -15,7 +15,7 @@
         <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="ContractPostfix" Visible="false" />
     </ItemGroup>
 
-    <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+    <Target Name="_InjectMediatorHttpAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun;GenerateMSBuildEditorConfigFileCore">
         <ItemGroup>
             <AdditionalFiles Include="@(MediatorHttp)" 
                              Namespace="%(MediatorHttp.Namespace)" 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the MediatorHttpRequestSourceGenerator doesn't work on `net9.0-desktop` targets in Uno projects.

## Problem
Uno.WinUI defines its own `_InjectAdditionalFiles` target which overrides the one in SourceGenerators.targets. This prevents MediatorHttp items from being added as AdditionalFiles for the source generator.

## Solution
Renamed the target to `_InjectMediatorHttpAdditionalFiles` to avoid the naming conflict.

## Changes
- Renamed `_InjectAdditionalFiles` to `_InjectMediatorHttpAdditionalFiles`
- Added `GenerateMSBuildEditorConfigFileCore` to BeforeTargets for better MSBuild compatibility

## Testing
- Tested locally in Orderlyze.Sales project
- Confirmed that MediatorHttp items are now processed correctly on desktop targets
- No breaking changes for existing projects

## Impact
This fix ensures the source generator works consistently across all target frameworks in Uno projects, including:
- net9.0-windows10.0.26100 ✅
- net9.0-desktop ✅ (previously broken)
- net9.0-browserwasm ✅

🤖 Generated with [Claude Code](https://claude.ai/code)