### PR TITLE
Add CPM configuration files for proper package management isolation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="src/Directory.build.props" />
+  
+  <!-- Override parent CPM settings to use local configuration -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,33 @@
+<Project>
+    <!--core project-->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
+    </ItemGroup>
+    
+    <!--support libs-->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.21"/>
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.0.0"/>
+        <PackageVersion Include="Dapper" Version="2.1.35"/>
+        <PackageVersion Include="InterpolatedSql.Dapper" Version="2.3.0"/>
+        <PackageVersion Include="FluentValidation" Version="12.0.0"/>
+        <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0"/>
+        <PackageVersion Include="Prism.Maui" Version="9.0.537"/>
+    </ItemGroup>
+    
+    <!--source generator-->
+    <ItemGroup>
+        <PackageVersion Include="SharpYaml" Version="2.1.3" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageVersion Include="Microsoft.OpenApi" Version="1.6.24" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.24" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all"/>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
Adds Central Package Management (CPM) configuration files to properly isolate this project's package management when used as a submodule.

## Problem
When this project is used as a submodule in a parent project that also uses CPM, NuGet throws NU1008 errors because it gets confused about which package versions to use. The error states that "Projects that use central package version management should not define the version on the PackageReference items" even though the project files don't have version attributes.

## Solution
Added two files at the repository root:
- `Directory.Build.props`: Imports the existing configuration from the src folder
- `Directory.Packages.props`: Copies the package versions from src/Directory.packages.props

This ensures that when used as a submodule, the project's CPM configuration is properly isolated from any parent project's configuration.

## Files Added
- `Directory.Build.props` - Imports src configuration and ensures CPM is enabled
- `Directory.Packages.props` - Contains all package versions (copied from src/Directory.packages.props)

## Testing
- Tested as a submodule in Orderlyze.Sales project
- Build completes successfully without NU1008 errors
- All package versions resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)